### PR TITLE
feat: Request and verify signed CoSERV responses when possible

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -527,7 +527,7 @@ dependencies = [
 [[package]]
 name = "coserv-rs"
 version = "0.1.0"
-source = "git+https://github.com/veraison/coserv-rs#014257f5c4e5ed8919419a87117ec44fc6e9e879"
+source = "git+https://github.com/veraison/coserv-rs#8725636d9526863abe890e67a18a714a6eda3b45"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -3316,7 +3316,7 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 [[package]]
 name = "veraison-apiclient"
 version = "0.0.2"
-source = "git+https://github.com/veraison/rust-apiclient#88a712421a424fa85730671a233d8cf5f64a36c3"
+source = "git+https://github.com/veraison/rust-apiclient#ff7ce874c1323c7f58374e49ae07bdecf98d8e3d"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ name = "ccacoserv-cli"
 path = "src/main.rs"
 
 [dependencies]
-coserv-rs = { git = "https://github.com/veraison/coserv-rs" }
+coserv-rs = { git = "https://github.com/veraison/coserv-rs", features = ["openssl"] }
 corim-rs = { git = "https://github.com/veraison/corim-rs" }
 cover = { git = "https://github.com/veraison/cover" }
 veraison-apiclient = { git = "https://github.com/veraison/rust-apiclient" }

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,6 +45,10 @@ struct Cli {
     #[arg(short, long, default_value_t = false, global = true)]
     force: bool,
 
+    /// The server MUST sign CoSERV results. The command fails if the server does not support signing.
+    #[arg(short = 'm', long, default_value_t = false, global = true)]
+    must_sign: bool,
+
     #[command(flatten)]
     verbosity: Verbosity<InfoLevel>,
 }


### PR DESCRIPTION
- Update dependencies so that we can use the sign/verify capabilities of `coserv-rs` and `rust-apiclient`
- Toggle on the `openssl` feature of `coserv-rs` so that we can use `OpenSslVerifier`
- Refactor the query client so that we can run the discovery phase just once rather than once for every query (this might also be important when we introduce caching later)
- Extend the discovery process to look at the verification key set, and construct an OpenSslVerifier when a verification key is available
- Unit tests for both unsigned and signed cases (since we know that the Veraison test server supports both)
- Main CLI flow will use signed results if the server supports them, but otherwise silently drops back to unsigned **UNLESS** the user insists on signatures by supplying `--must-sign` on the command line

Signed-off-by: Paul Howard <paul.howard@arm.com>