### PR TITLE
feat: Apply http caching to the discovery phase as well as the query phase

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1874,9 +1874,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.182"
+version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
 name = "linux-raw-sys"
@@ -2589,9 +2589,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.13"
+version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
  "aws-lc-rs",
  "bytes",
@@ -3383,12 +3383,12 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3847,7 +3847,7 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 [[package]]
 name = "veraison-apiclient"
 version = "0.0.2"
-source = "git+https://github.com/veraison/rust-apiclient#669299f72402467056f7686f739e135b3b576522"
+source = "git+https://github.com/veraison/rust-apiclient#b7e61e38cbbf4884e205a7cede35a6366db75be7"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -4562,18 +4562,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.40"
+version = "0.8.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a789c6e490b576db9f7e6b6d661bcc9799f7c0ac8352f56ea20193b2681532e5"
+checksum = "f2578b716f8a7a858b7f02d5bd870c14bf4ddbbcf3a4c05414ba6503640505e3"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.40"
+version = "0.8.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f65c489a7071a749c849713807783f70672b28094011623e200cb86dcb835953"
+checksum = "7e6cc098ea4d3bd6246687de65af3f920c430e236bee1e3bf2e441463f08a02f"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ path = "src/main.rs"
 coserv-rs = { git = "https://github.com/veraison/coserv-rs", features = ["openssl"] }
 corim-rs = { git = "https://github.com/veraison/corim-rs" }
 cover = { git = "https://github.com/veraison/cover" }
-veraison-apiclient = { git = "https://github.com/veraison/rust-apiclient", features = [ "coserv-disk-caching" ] }
+veraison-apiclient = { git = "https://github.com/veraison/rust-apiclient", features = [ "disk-caching" ] }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = { version = "1.0.140", features = ["raw_value"] }
 ccatoken = { git = "https://github.com/veraison/rust-ccatoken" }

--- a/src/query.rs
+++ b/src/query.rs
@@ -22,7 +22,9 @@ use coserv_rs::{
 };
 
 use veraison_apiclient::{
-    Discovery, DiscoveryBuilder, coserv::QueryRunner, coserv::QueryRunnerBuilder,
+    Discovery, DiscoveryBuilder,
+    coserv::{QueryRunner, QueryRunnerBuilder},
+    http::ConfigureHttp,
 };
 
 use crate::error::{Error, Result};
@@ -104,12 +106,18 @@ impl<'a> QueryClient {
         ca_cert: Option<&PathBuf>,
         cache_path: Option<&PathBuf>,
     ) -> Result<QueryClient> {
-        let discoverer = ca_cert
-            .map_or(DiscoveryBuilder::new(), |c| {
-                DiscoveryBuilder::new().with_root_certificate(c.clone())
-            })
-            .with_base_url(coserv_service_base_url.to_string())
-            .build()?;
+        let mut discovery_builder =
+            DiscoveryBuilder::new().with_base_url(coserv_service_base_url.to_string());
+
+        if let Some(some_ca_cert) = ca_cert {
+            discovery_builder = discovery_builder.with_root_certificate(some_ca_cert.clone());
+        }
+
+        if let Some(some_cache_path) = cache_path {
+            discovery_builder = discovery_builder.with_default_disk_cache(some_cache_path.clone());
+        }
+
+        let discoverer = discovery_builder.build()?;
 
         let discovery_doc = Discovery::get_coserv_discovery_document_json(&discoverer).await?;
 

--- a/src/query.rs
+++ b/src/query.rs
@@ -109,12 +109,12 @@ impl<'a> QueryClient {
         let mut discovery_builder =
             DiscoveryBuilder::new().with_base_url(coserv_service_base_url.to_string());
 
-        if let Some(some_ca_cert) = ca_cert {
-            discovery_builder = discovery_builder.with_root_certificate(some_ca_cert.clone());
+        if let Some(ca_cert) = ca_cert {
+            discovery_builder = discovery_builder.with_root_certificate(ca_cert.clone());
         }
 
-        if let Some(some_cache_path) = cache_path {
-            discovery_builder = discovery_builder.with_default_disk_cache(some_cache_path.clone());
+        if let Some(cache_path) = cache_path {
+            discovery_builder = discovery_builder.with_default_disk_cache(cache_path.clone());
         }
 
         let discoverer = discovery_builder.build()?;
@@ -139,12 +139,12 @@ impl<'a> QueryClient {
         let mut builder =
             QueryRunnerBuilder::new().with_request_response_url(coserv_request_response_url);
 
-        if let Some(some_ca_cert) = ca_cert {
-            builder = builder.with_root_certificate(some_ca_cert.clone());
+        if let Some(ca_cert) = ca_cert {
+            builder = builder.with_root_certificate(ca_cert.clone());
         }
 
-        if let Some(some_cache_path) = cache_path {
-            builder = builder.with_default_disk_cache(some_cache_path.clone());
+        if let Some(cache_path) = cache_path {
+            builder = builder.with_default_disk_cache(cache_path.clone());
         }
 
         let query_runner = builder.build()?;


### PR DESCRIPTION
- Update dependencies
- Feature name `coserv-disk-caching` changed to `disk-caching` for `rust-apiclient` dependency
- Command-line interface unchanged
- Configure (the same) cache path for `DiscoveryBuilder` as well as `QueryRunnerBuilder`
- This means caching is applied to the well-known discovery document as well as the actual query results
- This means zero reliance on the origin server while cached items are valid
- The demo can be run with the network unplugged until any of the cached items go stale

Signed-off-by: Paul Howard <paul.howard@arm.com>